### PR TITLE
Add support for language-specific homepages and translations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
     "semi": ["error", "always"],
     "complexity": ["error", { "max": 3 }],
     "max-lines": ["error", { "max": 100 }],
-    "max-statements": ["error", { "max": 5 },
+    "max-statements": ["error", { "max": 6 },
       { "ignoreTopLevelFunctions": true }
     ]
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,7 @@
       "rules": {
         "no-global-assign": 0,
         "max-lines": ["error", { "max": 300 }],
-        "max-statements": ["error", { "max": 10 },
+        "max-statements": ["error", { "max": 15 },
           { "ignoreTopLevelFunctions": true }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ module.exports = {
       someVar: 'someValue',
       anotherVar: 'anotherValue'
     }
+  },
+  // You can optionally set custom translations for labels used by Triven:
+  translations: {
+    'en-US': {
+      newer: 'Previous page',           // Default: 'Newer'
+      older: 'Next page',               // Default: 'Older'
+      readMore: 'Keep reading',         // Default: 'Read more'
+      seeAllPosts: 'All publications'   // Default: 'See all posts'
+    },
+    // You can add specific-language dictionaries if you have a multi-language blog:
+    'pt-BR': {
+      // Portuguese translations
+    }
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@glorious/triven",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@glorious/triven",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0-rc.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/triven",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A markdown-based blog generator",
   "main": "src/index.js",
   "bin": {

--- a/src/constants/translations.js
+++ b/src/constants/translations.js
@@ -1,0 +1,6 @@
+module.exports = {
+  newer: 'Newer',
+  older: 'Older',
+  readMore: 'Read more',
+  seeAllPosts: 'See all posts'
+};

--- a/src/mocks/brazil.md
+++ b/src/mocks/brazil.md
@@ -1,0 +1,6 @@
+title: Brazil
+date: 2021-06-25
+
+---
+
+Brazil (Portuguese: Brasil; Brazilian Portuguese: [bɾaˈziw]), officially the Federative Republic of Brazil, is the largest country in both South America and Latin America. It covers an area of 8,515,767 square kilometres (3,287,956 sq mi), with a population of over 211 million.

--- a/src/mocks/portuguese.md
+++ b/src/mocks/portuguese.md
@@ -1,0 +1,7 @@
+title: Publicação em Português
+date: 2021-08-06
+lang: pt-BR
+
+---
+
+Essa é uma publicação escrita em Português.

--- a/src/services/article.js
+++ b/src/services/article.js
@@ -5,6 +5,7 @@ const domService = require('./dom');
 const excerptService = require('./excerpt');
 const markdownService = require('./markdown');
 const templateService = require('./template');
+const translationService = require('./translation');
 
 const _public = {};
 
@@ -50,8 +51,9 @@ function wrapArticle({ title, date, lang }, article, languages){
 }
 
 function buildSeeAllPostsLink(languages, lang){
+  const { seeAllPosts } = translationService.get(lang);
   const href = languages.length > 1 ? `../l/${lang}` : '../';
-  return `<a href=${href}>See all posts</a>`;
+  return `<a href=${href}>${seeAllPosts}</a>`;
 }
 
 function buildMetaTags({ description = '', keywords = '' }){

--- a/src/services/article.test.js
+++ b/src/services/article.test.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const configService = require('./config');
 const { fileService } = require('./file');
+const postsService = require('./posts');
 const articleService = require('./article');
 
 describe('Articles Service', () => {
@@ -11,14 +12,29 @@ describe('Articles Service', () => {
   });
 
   it('should copy relative images to assets directory and update its source in markup', () => {
+    const filepaths = [path.join(__dirname, '../mocks/images.md')];
     const { outputDirectory } = configService.get();
-    const filepath = path.join(__dirname, '../mocks/images.md');
-    const { article } = articleService.build(filepath);
+    const [postData] = postsService.buildData(filepaths);
+    const { article } = articleService.build(postData);
     const expectedFilename = 'varejao-a8774002d2f7fef27b27f665c7e7227c.jpeg';
     expect(article).toContain(`<img src="../a/${expectedFilename}" alt="Adriana Varejão Gallery">`);
     expect(fileService.copySync).toHaveBeenCalledWith(
       `${path.join(__dirname, '../mocks/varejao.jpeg')}`,
       `${outputDirectory}/a/${expectedFilename}`
     );
+  });
+
+  it('should See All Posts link point to root if blog contains just one language', () => {
+    const filepaths = [path.join(__dirname, '../mocks/images.md')];
+    const [postData] = postsService.buildData(filepaths);
+    const { article } = articleService.build(postData, ['en-US']);
+    expect(article).toContain('<a href="../">See all posts</a>');
+  });
+
+  it('should See All Posts link point to language-specif homepage if blog contains more than one language', () => {
+    const filepaths = [path.join(__dirname, '../mocks/images.md')];
+    const [postData] = postsService.buildData(filepaths);
+    const { article } = articleService.build(postData, ['en-US', 'pt-BR']);
+    expect(article).toContain('<a href="../l/en-US">See all posts</a>');
   });
 });

--- a/src/services/article.test.js
+++ b/src/services/article.test.js
@@ -2,6 +2,7 @@ const path = require('path');
 const configService = require('./config');
 const { fileService } = require('./file');
 const postsService = require('./posts');
+const { mockTrivenConfig } = require('./testing');
 const articleService = require('./article');
 
 describe('Articles Service', () => {
@@ -36,5 +37,13 @@ describe('Articles Service', () => {
     const [postData] = postsService.buildData(filepaths);
     const { article } = articleService.build(postData, ['en-US', 'pt-BR']);
     expect(article).toContain('<a href="../l/en-US">See all posts</a>');
+  });
+
+  it('should optionally use custom translation for labels', () => {
+    mockTrivenConfig({ translations: { 'pt-BR': { seeAllPosts: 'Todas as publicações' } } });
+    const filepaths = [path.join(__dirname, '../mocks/portuguese.md')];
+    const [postData] = postsService.buildData(filepaths);
+    const { article } = articleService.build(postData, ['en-US', 'pt-BR']);
+    expect(article).toContain('<a href="../l/pt-BR">Todas as publicações</a>');
   });
 });

--- a/src/services/build.js
+++ b/src/services/build.js
@@ -5,6 +5,8 @@ const configService = require('./config');
 const dateService = require('./date');
 const domService = require('./dom');
 const homepageService = require('./homepage');
+const listService = require('./list');
+const postsService = require('./posts');
 const stylesService = require('./styles');
 const templateService = require('./template');
 
@@ -39,14 +41,25 @@ function handleMarkdownFiles(filepaths, sourceDirectory, outputDirectory, onComp
 
 function convertMarkdownFilesToHTML(filepaths, outputDirectory, onComplete){
   const summaries = [];
-  filepaths.forEach(filepath => buildArticle(filepath, outputDirectory, summary => summaries.push(summary)));
+  const { posts, languages } = buildPostsData(filepaths);
+  posts.forEach(post => buildArticle(post, outputDirectory, languages, summary => summaries.push(summary)));
   homepageService.build(summaries, outputDirectory);
   fileService.write(`${outputDirectory}/posts.json`, JSON.stringify(summaries));
   handleCompletion(onComplete);
 }
 
-function buildArticle(filepath, outputDirectory, onComplete){
-  const { summary, article } = articleService.build(filepath);
+function buildPostsData(filepaths){
+  const posts = postsService.buildData(filepaths);
+  const languages = identifyPostLanguages(posts.map(post => post.summary));
+  return { posts, languages };
+}
+
+function identifyPostLanguages(postSummaries){
+  return listService.rejectRepeatedValues(postSummaries.map(summary => summary.lang));
+}
+
+function buildArticle(data, outputDirectory, languages, onComplete){
+  const { summary, article, filepath } = articleService.build(data, languages);
   const filename = buildArticleFilename(outputDirectory, filepath);
   if(!summary.external) fileService.write(filename, domService.minifyHTML(article));
   onComplete(summary);

--- a/src/services/build.test.js
+++ b/src/services/build.test.js
@@ -6,6 +6,7 @@ const configService = require('./config');
 const dateService = require('./date');
 const domService = require('./dom');
 const homepageService = require('./homepage');
+const postsService = require('./posts');
 const buildService = require('./build');
 
 describe('Build Service', () => {
@@ -124,9 +125,11 @@ describe('Build Service', () => {
   });
 
   it('should build homepage', done => {
-    fileService.collect = jest.fn((pattern, onSuccess) => onSuccess([buildPathToMarkdownMock()]));
+    const filepaths = [buildPathToMarkdownMock()];
+    fileService.collect = jest.fn((pattern, onSuccess) => onSuccess(filepaths));
     const { outputDirectory } = configService.get();
-    const { summary } = articleService.build(path.join(__dirname, '../mocks/new-year.md'));
+    const [postData] = postsService.buildData(filepaths);
+    const { summary } = articleService.build(postData);
     buildService.init(() => {
       expect(homepageService.build).toHaveBeenCalledWith([summary], outputDirectory);
       done();
@@ -134,9 +137,11 @@ describe('Build Service', () => {
   });
 
   it('should save a JSON containing all post summaries', done => {
-    fileService.collect = jest.fn((pattern, onSuccess) => onSuccess([buildPathToMarkdownMock()]));
+    const filepaths = [buildPathToMarkdownMock()];
+    fileService.collect = jest.fn((pattern, onSuccess) => onSuccess(filepaths));
     const { outputDirectory } = configService.get();
-    const { summary } = articleService.build(path.join(__dirname, '../mocks/new-year.md'));
+    const [postData] = postsService.buildData(filepaths);
+    const { summary } = articleService.build(postData);
     buildService.init(() => {
       expect(fileService.write).toHaveBeenCalledWith(`${outputDirectory}/posts.json`, JSON.stringify([summary]));
       done();

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -39,11 +39,12 @@ function requireConfigFile(){
 }
 
 function parseCustomConfig(customConfig){
+  const defaultConfig = buildDefaultConfig();
   const customSourceDirectory = getCustomConfigPath(customConfig, 'sourceDirectory');
   const customOutputDirectory = getCustomConfigPath(customConfig, 'outputDirectory') || './triven';
   return {
+    ...defaultConfig,
     ...customConfig,
-    lang: customConfig.lang || getDefaultLanguage(),
     sourceDirectory: buildAbsoluteFilepath(customSourceDirectory),
     outputDirectory: buildAbsoluteFilepath(customOutputDirectory)
   };
@@ -57,7 +58,7 @@ function buildDefaultConfig(){
   const rootDirectory = getRootDirectory();
   return {
     title: 'Triven',
-    lang: getDefaultLanguage(),
+    lang: 'en-US',
     sourceDirectory: rootDirectory,
     outputDirectory: `${rootDirectory}/triven`
   };
@@ -69,10 +70,6 @@ function buildAbsoluteFilepath(relativeFilepath){
 
 function getRootDirectory(){
   return process.cwd();
-}
-
-function getDefaultLanguage(){
-  return 'en-US';
 }
 
 module.exports = _public;

--- a/src/services/config.test.js
+++ b/src/services/config.test.js
@@ -11,6 +11,7 @@ describe('Config Service', () => {
 
   function buildCustomConfig(){
     return {
+      title: 'My Title',
       lang: 'pt-BR',
       sourceDirectory: './src',
       outputDirectory: './blog'
@@ -52,6 +53,7 @@ describe('Config Service', () => {
   it('should get custom config', () => {
     stubRequire(buildCustomConfig());
     expect(configService.get()).toEqual({
+      title: 'My Title',
       lang: 'pt-BR',
       sourceDirectory: `${process.cwd()}/src`,
       outputDirectory: `${process.cwd()}/blog`
@@ -61,6 +63,7 @@ describe('Config Service', () => {
   it('should fallback to default directories if custom config has no source and output directories set', () => {
     stubRequire('');
     expect(configService.get()).toEqual({
+      title: 'Triven',
       lang: 'en-US',
       sourceDirectory: process.cwd(),
       outputDirectory: `${process.cwd()}/triven`

--- a/src/services/homepage-href.js
+++ b/src/services/homepage-href.js
@@ -1,0 +1,26 @@
+const _public = {};
+const TWO_DIRECTORIES_UP = '../../';
+const FOUR_DIRECTORIES_UP = '../../../../';
+
+_public.buildHrefPrefixes = ({ pageNumber, customLang }) => {
+  if(customLang) return buildPrefixesForSpecificLangHomepage(pageNumber);
+  return buildPrefixesForMultiLangHomepage(pageNumber);
+};
+
+function buildPrefixesForMultiLangHomepage(pageNumber){
+  return isFirstPage(pageNumber) ? buildPrefixes('') : buildPrefixes(TWO_DIRECTORIES_UP);
+}
+
+function buildPrefixesForSpecificLangHomepage(pageNumber){
+  return isFirstPage(pageNumber) ? buildPrefixes(TWO_DIRECTORIES_UP) : buildPrefixes(FOUR_DIRECTORIES_UP);
+}
+
+function isFirstPage(pageNumber){
+  return pageNumber === 1;
+}
+
+function buildPrefixes(levelsUp){
+  return { asset: levelsUp, post: levelsUp };
+}
+
+module.exports = _public;

--- a/src/services/homepage-href.test.js
+++ b/src/services/homepage-href.test.js
@@ -1,0 +1,35 @@
+const homepageHrefService = require('./homepage-href');
+
+describe('Homepage Href Service', () => {
+  it('should build appropriate href prefixes for the first page of a multi language home page', () => {
+    const params = { pageNumber: 1 };
+    expect(homepageHrefService.buildHrefPrefixes(params)).toEqual({
+      asset: '',
+      post: ''
+    });
+  });
+
+  it('should build appropriate href prefixes for pages other than first one of a multi language home page', () => {
+    const params = { pageNumber: 2 };
+    expect(homepageHrefService.buildHrefPrefixes(params)).toEqual({
+      asset: '../../',
+      post: '../../'
+    });
+  });
+
+  it('should build appropriate href prefix for the first page of a specific language home page', () => {
+    const params = { pageNumber: 1, customLang: 'es-ES' };
+    expect(homepageHrefService.buildHrefPrefixes(params)).toEqual({
+      asset: '../../',
+      post: '../../'
+    });
+  });
+
+  it('should build appropriate href prefix for pages other than first one of a specific language home page', () => {
+    const params = { pageNumber: 2, customLang: 'es-ES' };
+    expect(homepageHrefService.buildHrefPrefixes(params)).toEqual({
+      asset: '../../../../',
+      post: '../../../../'
+    });
+  });
+});

--- a/src/services/homepage.js
+++ b/src/services/homepage.js
@@ -6,16 +6,59 @@ const pageService = require('./page');
 const _public = {};
 
 _public.build = ([...postSummaries], outputDirectory) => {
-  const pages = listService.divideByNumberOfItems(orderByDateDesc(postSummaries));
-  pages.forEach((postPage, index) => {
-    const pageNumber = index + 1;
-    const page = pageService.build(postPage, { page: pageNumber, total: pages.length });
-    fileService.write(buildFilepath(outputDirectory, pageNumber), page);
-  });
+  const languages = identifyPostLanguages(postSummaries);
+  const postSummariesOrderedByDescDate = orderByDateDesc(postSummaries);
+  buildHomepages(postSummariesOrderedByDescDate, outputDirectory, buildAssetsPrefix);
+  buildLanguageSpecificHomepages(postSummariesOrderedByDescDate, outputDirectory, languages);
 };
 
+function identifyPostLanguages(postSummaries){
+  return listService.rejectRepeatedValues(postSummaries.map(summary => summary.lang));
+}
+
 function orderByDateDesc(postSummaries){
-  return postSummaries.sort((a, b) => a.date > b.date ? -1 : 1);
+  return [...postSummaries].sort((a, b) => a.date > b.date ? -1 : 1);
+}
+
+function buildLanguageSpecificHomepages(postSummaries, outputDirectory, languages){
+  languages.forEach(lang => {
+    buildHomepages(
+      filterPostSummariesByLang(postSummaries, lang),
+      `${outputDirectory}/l/${lang}`,
+      buildLanguageSpecificPageAssetsPrefix,
+      lang
+    );
+  });
+}
+
+function filterPostSummariesByLang(summaries, lang){
+  return summaries.filter(summary => summary.lang === lang);
+}
+
+function buildHomepages(postSummaries, outputDirectory, handleAssetsPrefixBuild, customLang){
+  const postSummaryPages = listService.divideByNumberOfItems(postSummaries);
+  postSummaryPages.forEach((postSummaries, index) => {
+    const pageNumber = index + 1;
+    const html = pageService.build(postSummaries, {
+      page: pageNumber,
+      total: postSummaryPages.length,
+      assetsDirPrefix: handleAssetsPrefixBuild(pageNumber),
+      customLang
+    });
+    fileService.write(buildFilepath(outputDirectory, pageNumber), html);
+  });
+}
+
+function buildAssetsPrefix(pageNumber){
+  return isFirstPage(pageNumber) ? '' : '../../';
+}
+
+function buildLanguageSpecificPageAssetsPrefix(pageNumber){
+  return isFirstPage(pageNumber) ? '../../' : '../../../../';
+}
+
+function isFirstPage(pageNumber){
+  return pageNumber === 1;
 }
 
 function buildFilepath(outputDirectory, pageNumber){

--- a/src/services/homepage.js
+++ b/src/services/homepage.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const listService = require('./list');
 const { fileService } = require('./file');
+const { buildHrefPrefixes } = require('./homepage-href');
 const pageService = require('./page');
 
 const _public = {};
@@ -8,7 +9,7 @@ const _public = {};
 _public.build = ([...postSummaries], outputDirectory) => {
   const languages = identifyPostLanguages(postSummaries);
   const postSummariesOrderedByDescDate = orderByDateDesc(postSummaries);
-  buildHomepages(postSummariesOrderedByDescDate, outputDirectory, buildAssetsPrefix);
+  buildHomepages(postSummariesOrderedByDescDate, outputDirectory);
   buildLanguageSpecificHomepages(postSummariesOrderedByDescDate, outputDirectory, languages);
 };
 
@@ -21,44 +22,33 @@ function orderByDateDesc(postSummaries){
 }
 
 function buildLanguageSpecificHomepages(postSummaries, outputDirectory, languages){
-  languages.forEach(lang => {
-    buildHomepages(
-      filterPostSummariesByLang(postSummaries, lang),
-      `${outputDirectory}/l/${lang}`,
-      buildLanguageSpecificPageAssetsPrefix,
-      lang
-    );
-  });
+  if(languages.length > 1) {
+    languages.forEach(lang => {
+      buildHomepages(
+        filterPostSummariesByLang(postSummaries, lang),
+        `${outputDirectory}/l/${lang}`,
+        lang
+      );
+    });
+  }
 }
 
 function filterPostSummariesByLang(summaries, lang){
   return summaries.filter(summary => summary.lang === lang);
 }
 
-function buildHomepages(postSummaries, outputDirectory, handleAssetsPrefixBuild, customLang){
+function buildHomepages(postSummaries, outputDirectory, customLang){
   const postSummaryPages = listService.divideByNumberOfItems(postSummaries);
   postSummaryPages.forEach((postSummaries, index) => {
     const pageNumber = index + 1;
     const html = pageService.build(postSummaries, {
       page: pageNumber,
       total: postSummaryPages.length,
-      assetsDirPrefix: handleAssetsPrefixBuild(pageNumber),
+      hrefPrefixes: buildHrefPrefixes({ pageNumber, customLang }),
       customLang
     });
     fileService.write(buildFilepath(outputDirectory, pageNumber), html);
   });
-}
-
-function buildAssetsPrefix(pageNumber){
-  return isFirstPage(pageNumber) ? '' : '../../';
-}
-
-function buildLanguageSpecificPageAssetsPrefix(pageNumber){
-  return isFirstPage(pageNumber) ? '../../' : '../../../../';
-}
-
-function isFirstPage(pageNumber){
-  return pageNumber === 1;
 }
 
 function buildFilepath(outputDirectory, pageNumber){

--- a/src/services/homepage.test.js
+++ b/src/services/homepage.test.js
@@ -24,7 +24,7 @@ describe('Homepage Service', () => {
     const [first, second, third] = postsMock;
     const orderedPosts = [second, third, first];
     homepageService.build(postsMock, '');
-    expect(pageService.build).toHaveBeenCalledWith(orderedPosts, { page: 1, total: 1, assetsDirPrefix: '' });
+    expect(pageService.build).toHaveBeenCalledWith(orderedPosts, expect.any(Object));
   });
 
   it('should save home page files according to their page numbers', () => {
@@ -32,11 +32,11 @@ describe('Homepage Service', () => {
     const postsMock = new Array(25);
     const { html } = stubPageBuild();
     homepageService.build(postsMock.fill({ some: 'postSummary' }), outputDirectory);
-    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 1, total: 3, assetsDirPrefix: '' });
+    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 1, total: 3, hrefPrefixes: { asset: '', post: '' }, customLang: undefined });
     expect(fileService.write).toHaveBeenCalledWith(`${outputDirectory}/index.html`, html);
-    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 2, total: 3, assetsDirPrefix: '../../' });
+    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 2, total: 3, hrefPrefixes: { asset: '../../', post: '../../' }, customLang: undefined });
     expect(fileService.write).toHaveBeenCalledWith(`${outputDirectory}/p/2/index.html`, html);
-    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 3, total: 3, assetsDirPrefix: '../../' });
+    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 3, total: 3, hrefPrefixes: { asset: '../../', post: '../../' }, customLang: undefined });
     expect(fileService.write).toHaveBeenCalledWith(`${outputDirectory}/p/3/index.html`, html);
   });
 
@@ -55,13 +55,21 @@ describe('Homepage Service', () => {
     const allPostsMock = [...englishPostsMock.fill({ lang: 'en-US' }), ...portuguesePostsMock.fill({ lang: 'pt-BR' })];
     const { html } = stubPageBuild();
     homepageService.build(allPostsMock, outputDirectory);
-    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 1, total: 2, assetsDirPrefix: '../../', customLang: 'en-US' });
+    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 1, total: 2, hrefPrefixes: { asset: '../../', post: '../../' }, customLang: 'en-US' });
     expect(fileService.write).toHaveBeenCalledWith(`${outputDirectory}/l/en-US/index.html`, html);
-    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 2, total: 2, assetsDirPrefix: '../../../../', customLang: 'en-US' });
+    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 2, total: 2, hrefPrefixes: { asset: '../../../../', post: '../../../../' }, customLang: 'en-US' });
     expect(fileService.write).toHaveBeenCalledWith(`${outputDirectory}/l/en-US/p/2/index.html`, html);
-    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 1, total: 2, assetsDirPrefix: '../../', customLang: 'pt-BR' });
+    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 1, total: 2, hrefPrefixes: { asset: '../../', post: '../../' }, customLang: 'pt-BR' });
     expect(fileService.write).toHaveBeenCalledWith(`${outputDirectory}/l/pt-BR/index.html`, html);
-    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 2, total: 2, assetsDirPrefix: '../../../../', customLang: 'pt-BR' });
+    expect(pageService.build).toHaveBeenCalledWith(expect.any(Array), { page: 2, total: 2, hrefPrefixes: { asset: '../../../../', post: '../../../../' }, customLang: 'pt-BR' });
     expect(fileService.write).toHaveBeenCalledWith(`${outputDirectory}/l/pt-BR/p/2/index.html`, html);
+  });
+
+  it('should not save language-specific home page files if all posts are written in the same language', () => {
+    stubPageBuild();
+    const outputDirectory = buildFakeOutputDirectoryFilepath();
+    const [first, second] = postsMock;
+    homepageService.build([first, second], outputDirectory);
+    expect(fileService.write).not.toHaveBeenCalledWith(`${outputDirectory}/l/en-US/index.html`, expect.any(String));
   });
 });

--- a/src/services/list.js
+++ b/src/services/list.js
@@ -1,9 +1,17 @@
 const _public = {};
 
-_public.divideByNumberOfItems = (items, { numberOfItems = 10 } = {}) => {
+_public.divideByNumberOfItems = ([...items], { numberOfItems = 10 } = {}) => {
   const pages = [];
   splitItemsInPages(pages, items, numberOfItems);
   return pages;
+};
+
+_public.rejectRepeatedValues = list => {
+  const uniqueValues = [];
+  list.forEach(item => {
+    if(!uniqueValues.includes(item)) uniqueValues.push(item);
+  });
+  return uniqueValues;
 };
 
 function splitItemsInPages(pages, items, numberOfItems){

--- a/src/services/list.test.js
+++ b/src/services/list.test.js
@@ -21,4 +21,11 @@ describe('List Service', () => {
     expect(pages[2]).toEqual([13,14,15,16,17,18]);
     expect(pages[3]).toEqual([19,20,21,22,23,24]);
   });
+
+  it('should reject repeated values in a list', () => {
+    const list = [1, 'a', 'a', '1', 2, 2, 3, true, 'true', true];
+    expect(listService.rejectRepeatedValues(list)).toEqual([
+      1, 'a', '1', 2, 3, true, 'true'
+    ]);
+  });
 });

--- a/src/services/markdown.js
+++ b/src/services/markdown.js
@@ -3,8 +3,8 @@ const marked = require('marked');
 
 const _public = {};
 
-_public.convert = htmlString => {
-  return marked(htmlString, { headerIds: false, highlight });
+_public.convert = markdownText => {
+  return marked(markdownText, { headerIds: false, highlight });
 };
 
 function highlight(code, lang){

--- a/src/services/metadata.js
+++ b/src/services/metadata.js
@@ -1,0 +1,8 @@
+const _public = {};
+
+_public.hasMetadata = fileContent => {
+  const containsMetadataDivider = new RegExp(/^---\n$/m);
+  return containsMetadataDivider.test(fileContent);
+};
+
+module.exports = _public;

--- a/src/services/metadata.test.js
+++ b/src/services/metadata.test.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const { fileService } = require('./file');
+const metadataService = require('./metadata');
+
+describe('Metadata Service', () => {
+  function readMockFile(filename){
+    return fileService.readSync(path.join(__dirname, `../mocks/${filename}`));
+  }
+
+  it('should detect if metadata is present on file', () => {
+    expect(metadataService.hasMetadata(readMockFile('brazil.md'))).toEqual(true);
+    expect(metadataService.hasMetadata(readMockFile('images.md'))).toEqual(false);
+  });
+});

--- a/src/services/page.js
+++ b/src/services/page.js
@@ -4,23 +4,23 @@ const templateService = require('./template');
 
 const _public = {};
 
-_public.build = (posts, { page, total, assetsDirPrefix = '', customLang }) => {
-  const body = buildPageBody(posts, page, total);
-  return domService.minifyHTML(buildPage(body, assetsDirPrefix, customLang));
+_public.build = (posts, { page, total, hrefPrefixes = {}, customLang }) => {
+  const body = buildPageBody(posts, page, total, hrefPrefixes.post);
+  return domService.minifyHTML(buildPage(body, hrefPrefixes.asset, customLang));
 };
 
-function buildPageBody(posts, page, total){
+function buildPageBody(posts, page, total, postHrefPrefix){
   return `
     <main class="tn-main">
-      ${buildPostList(posts, page)}
+      ${buildPostList(posts, page, postHrefPrefix)}
       ${buildFooter(page, total)}
     </main>
   `;
 }
 
-function buildPostList(posts, page){
+function buildPostList(posts, page, postHrefPrefix = ''){
   const items = posts.map(post => {
-    const href = buildPostHref(post.url, page);
+    const href = buildPostHref(post.url, postHrefPrefix);
     return `
       <li>
         <section>
@@ -70,8 +70,8 @@ function handleLinkAttrs({ external }){
   return external ? 'rel="noopener noreferrer" target="_blank"' : '';
 }
 
-function buildPostHref(href, page){
-  const prefix = page > 1 && !href.includes('http') ? '../../' : '';
+function buildPostHref(href, postHrefPrefix){
+  const prefix = !href.includes('http') ? postHrefPrefix : '';
   return `${prefix}${href.replace('.html', '')}`;
 }
 

--- a/src/services/page.js
+++ b/src/services/page.js
@@ -4,9 +4,9 @@ const templateService = require('./template');
 
 const _public = {};
 
-_public.build = (posts, { page, total }) => {
+_public.build = (posts, { page, total, assetsDirPrefix = '', customLang }) => {
   const body = buildPageBody(posts, page, total);
-  return domService.minifyHTML(buildPage(body, page));
+  return domService.minifyHTML(buildPage(body, assetsDirPrefix, customLang));
 };
 
 function buildPageBody(posts, page, total){
@@ -75,8 +75,8 @@ function buildPostHref(href, page){
   return `${prefix}${href.replace('.html', '')}`;
 }
 
-function buildPage(body, pageNumber){
-  const template = templateService.getHomepageTemplate({ pageNumber });
+function buildPage(body, assetsDirPrefix, customLang){
+  const template = templateService.getHomepageTemplate({ assetsDirPrefix, customLang });
   return templateService.replaceVar(template, 'triven:posts', body);
 }
 

--- a/src/services/page.js
+++ b/src/services/page.js
@@ -1,29 +1,33 @@
+const configService = require('./config');
 const dateService = require('./date');
 const domService = require('./dom');
 const templateService = require('./template');
+const translationService = require('./translation');
 
 const _public = {};
 
 _public.build = (posts, { page, total, hrefPrefixes = {}, customLang }) => {
-  const body = buildPageBody(posts, page, total, hrefPrefixes.post);
-  return domService.minifyHTML(buildPage(body, hrefPrefixes.asset, customLang));
+  const pageLang = customLang || configService.get().lang;
+  const body = buildPageBody(posts, page, total, hrefPrefixes.post, pageLang);
+  return domService.minifyHTML(buildPage(body, hrefPrefixes.asset, pageLang));
 };
 
-function buildPageBody(posts, page, total, postHrefPrefix){
+function buildPageBody(posts, page, total, postHrefPrefix, pageLang){
   return `
     <main class="tn-main">
-      ${buildPostList(posts, page, postHrefPrefix)}
-      ${buildFooter(page, total)}
+      ${buildPostList(posts, page, postHrefPrefix, pageLang)}
+      ${handleFooter(page, total, getTranslations(pageLang))}
     </main>
   `;
 }
 
-function buildPostList(posts, page, postHrefPrefix = ''){
+function buildPostList(posts, page, postHrefPrefix = '', pageLang){
   const items = posts.map(post => {
+    const translations = getTranslations(post.lang);
     const href = buildPostHref(post.url, postHrefPrefix);
     return `
       <li>
-        <section>
+        <section ${handleSectionLangAttribute(pageLang, post.lang)}>
           <header class="tn-header">
             <h2 class="tn-post-title">
               <a href="${href}" ${handleLinkAttrs(post)}>${post.title}</a>
@@ -33,7 +37,7 @@ function buildPostList(posts, page, postHrefPrefix = ''){
           <p>${post.excerpt}</p>
           <footer class="tn-footer">
             <a href="${href}" ${handleLinkAttrs(post)} class="tn-read-more-link">
-              Read more
+              ${translations.readMore}
             </a>
           </footer>
         </section>
@@ -43,22 +47,30 @@ function buildPostList(posts, page, postHrefPrefix = ''){
   return `<ul class="tn-post-list">${items}</ul>`;
 }
 
-function buildFooter(page, total){
-  const prevLink = buildPreviousPageLink(page);
-  const nextLink = buildNextPageLink(page, total);
-  return prevLink || nextLink ? `<footer class="tn-footer"><nav>${prevLink}${nextLink}</nav></footer>` : '';
+function handleSectionLangAttribute(pageLang, postLang){
+  return pageLang !== postLang ? `lang="${postLang}"` : '';
 }
 
-function buildPreviousPageLink(page){
-  return page > 1 ? `<a href="${buildPreviousPageLinkHref(page)}" class="tn-newer-link">Newer</a>` : '';
+function handleFooter(page, total, translations){
+  const prevLink = buildPreviousPageLink(page, translations);
+  const nextLink = buildNextPageLink(page, total, translations);
+  return prevLink || nextLink ? buildFooter(prevLink, nextLink) : '';
+}
+
+function buildFooter(prevLink, nextLink){
+  return `<footer class="tn-footer"><nav>${prevLink}${nextLink}</nav></footer>`;
+}
+
+function buildPreviousPageLink(page, { newer }){
+  return page > 1 ? `<a href="${buildPreviousPageLinkHref(page)}" class="tn-newer-link">${newer}</a>` : '';
 }
 
 function buildPreviousPageLinkHref(page){
   return page === 2 ? '../../' : `../${page - 1}`;
 }
 
-function buildNextPageLink(page, total){
-  return page !== total ? `<a href="${buildNextPageLinkHref(page)}" class="tn-older-link">Older</a>` : '';
+function buildNextPageLink(page, total, { older }){
+  return page !== total ? `<a href="${buildNextPageLinkHref(page)}" class="tn-older-link">${older}</a>` : '';
 }
 
 function buildNextPageLinkHref(page){
@@ -78,6 +90,10 @@ function buildPostHref(href, postHrefPrefix){
 function buildPage(body, assetsDirPrefix, customLang){
   const template = templateService.getHomepageTemplate({ assetsDirPrefix, customLang });
   return templateService.replaceVar(template, 'triven:posts', body);
+}
+
+function getTranslations(lang){
+  return translationService.get(lang);
 }
 
 module.exports = _public;

--- a/src/services/page.test.js
+++ b/src/services/page.test.js
@@ -6,9 +6,9 @@ const stylesService = require('./styles');
 const { mockTrivenConfig } = require('./testing');
 
 describe('Page Service', () => {
-  function buildPage(posts, { page, total }, onBuild){
+  function buildPage(posts, { page, total, assetsDirPrefix, customLang }, onBuild){
     stylesService.buildBaseStyle('', () => {
-      const result = pageService.build(posts, { page, total });
+      const result = pageService.build(posts, { page, total, assetsDirPrefix, customLang });
       onBuild(result);
     });
   }
@@ -102,10 +102,10 @@ describe('Page Service', () => {
     });
   });
 
-  it('should contain a prefixed base stylesheet linked in the html head if page is greater than one', done => {
-    buildPage(postsMock, { page: 2, total: 2 }, page => {
+  it('should optionally prefix assets linked in the html', done => {
+    buildPage(postsMock, { page: 2, total: 2, assetsDirPrefix: '../../../../' }, page => {
       expect(page).toContain(domService.minifyHTML(`
-        <link rel="stylesheet" href="../../a/triven-${getExpectedTrivenStylesheetHash()}.css">
+        <link rel="stylesheet" href="../../../../a/triven-${getExpectedTrivenStylesheetHash()}.css">
       `));
       done();
     });
@@ -181,11 +181,21 @@ describe('Page Service', () => {
     });
   });
 
-  it('should optionally set page language according to custom language', done => {
+  it('should set page language according to the language set on triven config file by default', done => {
     const lang = 'pt-BR';
     mockTrivenConfig({ lang });
     buildPage(postsMock, { page: 1, total: 1 }, page => {
       expect(page).toContain(`<html lang="${lang}">`);
+      done();
+    });
+  });
+
+  it('should optionally set language other than language set on triven config file', done => {
+    const lang = 'pt-BR';
+    const customLang = 'es-ES';
+    mockTrivenConfig({ lang });
+    buildPage(postsMock, { page: 1, total: 1, customLang }, page => {
+      expect(page).toContain(`<html lang="${customLang}">`);
       done();
     });
   });

--- a/src/services/page.test.js
+++ b/src/services/page.test.js
@@ -72,7 +72,7 @@ describe('Page Service', () => {
                   </section>
                 </li>
                 <li>
-                  <section>
+                  <section lang="pt-BR">
                     <header class="tn-header">
                       <h2 class="tn-post-title">
                         <a href="https://rafaelcamargo.com/incondicional-inhotim" rel="noopener noreferrer" target="_blank">
@@ -202,6 +202,35 @@ describe('Page Service', () => {
     mockTrivenConfig({ lang });
     buildPage(postsMock, { page: 1, total: 1, customLang }, page => {
       expect(page).toContain(`<html lang="${customLang}">`);
+      done();
+    });
+  });
+
+  it('should optionally use custom translations for labels', done => {
+    const lang = 'pt-BR';
+    const newer = 'Posteriores';
+    const older = 'Anteriores';
+    mockTrivenConfig({ translations: { [lang]: { newer, older } } });
+    buildPage(postsMock, { page: 3, total: 6, customLang: lang }, page => {
+      expect(page).toContain(`<a href="../2" class="tn-newer-link">${newer}</a>`);
+      expect(page).toContain(`<a href="../4" class="tn-older-link">${older}</a>`);
+      done();
+    });
+  });
+
+  it('should optionally use custom translations for "Read more" links', done => {
+    mockTrivenConfig({ translations: { 'pt-BR': { readMore: 'Continue lendo' } } });
+    buildPage(postsMock, { page: 1, total: 1 }, page => {
+      expect(page).toContain(domService.minifyHTML(`
+        <a href="new-year" class="tn-read-more-link">
+          Read more
+        </a>
+      `));
+      expect(page).toContain(domService.minifyHTML(`
+        <a href="https://rafaelcamargo.com/incondicional-inhotim" rel="noopener noreferrer" target="_blank" class="tn-read-more-link">
+          Continue lendo
+        </a>
+      `));
       done();
     });
   });

--- a/src/services/posts.js
+++ b/src/services/posts.js
@@ -1,0 +1,20 @@
+const { fileService } = require('./file');
+const metadataService = require('./metadata');
+const summaryService = require('./summary');
+
+const _public = {};
+
+_public.buildData = filepaths => {
+  return filepaths.map(filepath => {
+    const fileContent = fileService.readSync(filepath);
+    const summary = summaryService.build(fileContent, filepath);
+    return { summary, markdownText: removeMetadataLines(fileContent), filepath };
+  });
+};
+
+function removeMetadataLines(fileContent){
+  if(!metadataService.hasMetadata(fileContent)) return fileContent;
+  return fileContent.slice(fileContent.indexOf('---')+3).trim();
+}
+
+module.exports = _public;

--- a/src/services/posts.test.js
+++ b/src/services/posts.test.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const postsService = require('./posts');
+const { mockTrivenConfig } = require('./testing');
+
+describe('Posts Service', () => {
+  function buildMockFilepaths(){
+    return [path.join(__dirname, '../mocks/brazil.md')];
+  }
+
+  beforeEach(() => {
+    mockTrivenConfig({});
+  });
+
+  it('should build a list of post data form post filepaths', () => {
+    const markdownText = `title: Brazil
+date: 2021-06-25
+
+---
+
+Brazil (Portuguese: Brasil; Brazilian Portuguese: [bɾaˈziw]), officially the Federative Republic of Brazil, is the largest country in both South America and Latin America. It covers an area of 8,515,767 square kilometres (3,287,956 sq mi), with a population of over 211 million.
+`;
+    const filepaths = buildMockFilepaths();
+    expect(postsService.buildData(filepaths)).toEqual([
+      {
+        summary: {
+          title: 'Brazil',
+          lang: 'en-US',
+          date: '2021-06-25',
+          url: 'brazil.html'
+        },
+        markdownText: markdownText.slice(markdownText.indexOf('---')+3).trim(),
+        filepath: filepaths[0]
+      }
+    ]);
+  });
+});

--- a/src/services/summary.js
+++ b/src/services/summary.js
@@ -5,9 +5,14 @@ const _public = {};
 
 _public.build = (fileContent, filepath) => {
   const baseSummary = { title: 'Untitled', lang: configService.get().lang };
-  const customSummary = buildCustomSummary(fileContent.split('\n'));
+  const customSummary = hasMetadata(fileContent) ? buildCustomSummary(fileContent.split('\n')) : {};
   return appendUrl({ ...baseSummary, ...customSummary }, filepath);
 };
+
+function hasMetadata(fileContent){
+  const containsMetadataDivider = new RegExp(/^---\n$/m);
+  return containsMetadataDivider.test(fileContent);
+}
 
 function buildCustomSummary(lines){
   const customSummary = {};

--- a/src/services/summary.test.js
+++ b/src/services/summary.test.js
@@ -98,10 +98,19 @@ Here is the first article paragraph.
 
   it('should optionally contain a custom language', () => {
     const lang = 'pt-BR';
-    expect(summaryService.build(buildMarkdownFileMock({ lang }), 'sem-titulo.md')).toEqual({
+    expect(summaryService.build(buildMarkdownFileMock({ lang }), 'untitled.md')).toEqual({
       title: 'Untitled',
-      url: 'sem-titulo.html',
+      url: 'untitled.html',
       lang
+    });
+  });
+
+  it('should return a default summary if no metadata has been found on markdown file', () => {
+    const markdown = '![Valeska Soares Gallery](http://valeskasoares.net/wp-content/uploads/2009/10/DSC8218.jpg)';
+    expect(summaryService.build(markdown, 'untitled.md')).toEqual({
+      title: 'Untitled',
+      url: 'untitled.html',
+      lang: 'en-US'
     });
   });
 });

--- a/src/services/template.js
+++ b/src/services/template.js
@@ -9,9 +9,9 @@ const _public = {};
 
 _public.getArticleTemplate = () => getTemplateByName('article', '../');
 
-_public.getHomepageTemplate = ({ pageNumber } = {}) => {
+_public.getHomepageTemplate = ({ assetsDirPrefix = '', customLang } = {}) => {
   const { title, lang } = configService.get();
-  const template = setLang(getTemplateByName('homepage', buildHomepageAssetsDirectoryPrefix(pageNumber)), lang);
+  const template = setLang(getTemplateByName('homepage', assetsDirPrefix), customLang || lang);
   const $ = parseHTMLString(template);
   title && $('head').append(`<title>${title}</title>`);
   return $.html();
@@ -30,10 +30,6 @@ function getTemplateByName(name, assetsDirPrefix){
     buildBaseMetaTags(parseTemplate(fileService.readSync(filepath), path.dirname(filepath), assetsDirPrefix)) :
     buildBaseMetaTags(getByFilename(`${name}.html`));
   return includeBaseStylesheet(template, assetsDirPrefix);
-}
-
-function buildHomepageAssetsDirectoryPrefix(pageNumber){
-  return pageNumber > 1 ? '../../' : '';
 }
 
 function parseTemplate(htmlString, baseDir, assetsDirPrefix){

--- a/src/services/template.test.js
+++ b/src/services/template.test.js
@@ -17,6 +17,10 @@ describe('Template Service', () => {
     console.log = jest.fn();
   });
 
+  afterEach(() => {
+    mockTrivenConfig({});
+  });
+
   it('should get default article template if no custom template has been found', done => {
     const expectedMarkup = domService.minifyHTML(`
       <!DOCTYPE html>
@@ -92,6 +96,7 @@ describe('Template Service', () => {
           <meta charset="ISO-8859-1">
           <meta name="viewport" content="width=device-width, initial-scale=1">
           <link rel="stylesheet" href="a/triven-09bc413584c654bbd435f02cf242839d.css">
+          <title>Triven</title>
         </head>
         <body>
           {{ triven:posts }}
@@ -143,6 +148,7 @@ describe('Template Service', () => {
           <meta charset="utf-8">
           <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5">
           <link rel="stylesheet" href="a/triven-09bc413584c654bbd435f02cf242839d.css">
+          <title>Triven</title>
         </head>
         <body>
           <h1>My Custom Homepage Title</h1>
@@ -258,8 +264,17 @@ describe('Template Service', () => {
       css: `${ASSETS_DIRNAME}/sample-971f848e8154ff6b2243ec1a1da4abc0.css`
     };
     mount(() => {
-      const template = templateService.getHomepageTemplate({ pageNumber: 2 });
+      const template = templateService.getHomepageTemplate({ assetsDirPrefix: '../../' });
       expect(template).toContain(`<link href="../../${filenames.css}" rel="stylesheet">`);
+      done();
+    });
+  });
+
+  it('should optionally set a custom language on homepage template', done => {
+    mount(() => {
+      const customLang = 'es-ES';
+      const template = templateService.getHomepageTemplate({ customLang });
+      expect(template).toContain('<html lang="es-ES">');
       done();
     });
   });

--- a/src/services/translation.js
+++ b/src/services/translation.js
@@ -1,0 +1,16 @@
+const baseTranslations = require('../constants/translations');
+const configService = require('./config');
+
+const _public = {};
+
+_public.get = lang => {
+  const translations = getCustomTranslations(lang);
+  return { ...baseTranslations, ...translations };
+};
+
+function getCustomTranslations(lang){
+  const { translations } = configService.get();
+  if(translations) return translations[lang];
+}
+
+module.exports = _public;

--- a/src/services/translation.test.js
+++ b/src/services/translation.test.js
@@ -1,0 +1,49 @@
+const { mockTrivenConfig } = require('./testing');
+const translationService = require('./translation');
+
+describe('Translation Service', () => {
+  beforeEach(() => {
+    console.log = jest.fn();
+  });
+
+  it('should get default translations', () => {
+    expect(translationService.get()).toEqual({
+      newer: 'Newer',
+      older: 'Older',
+      readMore: 'Read more',
+      seeAllPosts: 'See all posts'
+    });
+  });
+
+  it('should optionally get custom english translations', () => {
+    const lang = 'en-US';
+    const newer = 'Previous page';
+    const older = 'Next page';
+    mockTrivenConfig({ translations: { [lang]: { newer, older } } });
+    expect(translationService.get(lang)).toEqual({
+      newer,
+      older,
+      readMore: 'Read more',
+      seeAllPosts: 'See all posts'
+    });
+  });
+
+  it('should optionally get custom translations for custom language', () => {
+    const lang = 'pt-BR';
+    const newer = 'Posteriores';
+    const older = 'Anteriores';
+    const readMore = 'Continue lendo';
+    const seeAllPosts = 'Todas as publicações';
+    mockTrivenConfig({
+      translations: {
+        [lang]: { newer, older, readMore, seeAllPosts }
+      }
+    });
+    expect(translationService.get(lang)).toEqual({
+      newer,
+      older,
+      readMore,
+      seeAllPosts
+    });
+  });
+});


### PR DESCRIPTION
This Pull Request introduces the necessary changes to offer the possibility to translate Triven labels like "Read more", "See all posts", etc.

In addition, Triven will generate language-specific homepages for blogs containing posts written in more than one language.