### PR TITLE
Improve a11y for "read more" links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@glorious/triven",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@glorious/triven",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0-rc.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/triven",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A markdown-based blog generator",
   "main": "src/index.js",
   "bin": {

--- a/src/services/page.js
+++ b/src/services/page.js
@@ -40,7 +40,7 @@ function buildPostList(posts, page, postHrefPrefix = '', lang){
           <p>${post.excerpt}</p>
           <footer class="tn-footer">
             <a href="${href}" ${handleLinkAttrs(post)} class="tn-read-more-link">
-              ${translations.readMore}
+              ${translations.readMore}<span class="tn-screen-reader-only">: ${post.title}</span>
             </a>
           </footer>
         </article>

--- a/src/services/page.test.js
+++ b/src/services/page.test.js
@@ -44,7 +44,7 @@ describe('Page Service', () => {
                     <p>This is an excerpt for the first post</p>
                     <footer class="tn-footer">
                       <a href="new-year" class="tn-read-more-link">
-                        Read more
+                        Read more<span class="tn-screen-reader-only">: New year!</span>
                       </a>
                     </footer>
                   </article>
@@ -62,7 +62,7 @@ describe('Page Service', () => {
                     <p>This is an excerpt for the second post</p>
                     <footer class="tn-footer">
                       <a href="https://rafaelcamargo.com/the-pearl-and-the-mussels" rel="noopener noreferrer" target="_blank" class="tn-read-more-link">
-                        Read more
+                        Read more<span class="tn-screen-reader-only">: The pearl and the mussels</span>
                       </a>
                     </footer>
                   </article>
@@ -80,7 +80,7 @@ describe('Page Service', () => {
                     <p>Esse é um excerto para o terceiro artigo.</p>
                     <footer class="tn-footer">
                       <a href="https://rafaelcamargo.com/incondicional-inhotim" rel="noopener noreferrer" target="_blank" class="tn-read-more-link">
-                        Read more
+                        Read more<span class="tn-screen-reader-only">: Incondicional Inhotim</span>
                       </a>
                     </footer>
                   </article>
@@ -122,7 +122,7 @@ describe('Page Service', () => {
       expect(page).toContain(domService.minifyHTML(`
         <footer class="tn-footer">
           <a href="../../../../new-year" class="tn-read-more-link">
-            Read more
+            Read more<span class="tn-screen-reader-only">: New year!</span>
           </a>
         </footer>
       `));
@@ -185,7 +185,11 @@ describe('Page Service', () => {
     const second = postsMock[1];
     buildPage([second], { page: 2, total: 2 }, page => {
       expect(page).toContain(`<h2 class="tn-post-title"><a href="${second.url}" rel="noopener noreferrer" target="_blank">${second.title}</a></h2>`);
-      expect(page).toContain(`<a href="${second.url}" rel="noopener noreferrer" target="_blank" class="tn-read-more-link">Read more</a>`);
+      expect(page).toContain([
+        `<a href="${second.url}" rel="noopener noreferrer" target="_blank" class="tn-read-more-link">`,
+        `Read more<span class="tn-screen-reader-only">: ${second.title}</span>`,
+        '</a>'
+      ].join(''));
       done();
     });
   });
@@ -226,12 +230,12 @@ describe('Page Service', () => {
     buildPage(postsMock, { page: 1, total: 1 }, page => {
       expect(page).toContain(domService.minifyHTML(`
         <a href="new-year" class="tn-read-more-link">
-          Read more
+          Read more<span class="tn-screen-reader-only">: New year!</span>
         </a>
       `));
       expect(page).toContain(domService.minifyHTML(`
         <a href="https://rafaelcamargo.com/incondicional-inhotim" rel="noopener noreferrer" target="_blank" class="tn-read-more-link">
-          Continue lendo
+          Continue lendo<span class="tn-screen-reader-only">: Incondicional Inhotim</span>
         </a>
       `));
       done();

--- a/src/services/testing.js
+++ b/src/services/testing.js
@@ -9,7 +9,7 @@ _public.mockTrivenConfig = customConfig => {
 };
 
 _public.getExpectedTrivenStylesheetHash = () => {
-  return '56c63fac93c7c7d4116654da60632c74';
+  return '6b298bc74db67e12692bd769105619ce';
 };
 
 function buildFilesMock(customConfig){

--- a/src/styles/base.styl
+++ b/src/styles/base.styl
@@ -152,8 +152,9 @@ p > code
         transform rotate(-135deg)
     .tn-settings-list
       top -5px
+      width auto
+      height auto
       opacity 1
-      visibility visible
     & + .tn-settings-list-hiding-trigger
       display block
 
@@ -206,14 +207,16 @@ p > code
   top 15px
   margin 0
   padding 0
+  width 0
+  height 0
   list-style-type none
   background-color #FFF
   border 1px solid $color-grey-light
   border-radius 4px
   opacity 0
-  visibility hidden
   transform translateY(-100%)
   transition opacity .2s ease-out, top .2s ease-out
+  overflow hidden
   li
     &:not(:first-child)
       border-top 1px solid $color-grey-light
@@ -234,4 +237,6 @@ p > code
     right 0
 
 .tn-screen-reader-only
-  display none
+  display inline-block
+  height 0
+  text-indent -9999px

--- a/src/templates/introducing-triven.md
+++ b/src/templates/introducing-triven.md
@@ -15,14 +15,14 @@ Before getting started with Triven, you need to install it in your project as fo
 npm install -D @glorious/triven
 ```
 
-After installing it, you can see Triven in action just running:
+After installing it, you can see Triven in action by running the following command:
 ```
 npx triven build
 ```
 It will create a blog ready to be published in a directory called `triven` in the root of your project.
 You can optionally customize some build details as the source directory for Markdown files, the output directory for the final files generated, among other things.
 
-Refer to [Triven's Docmentation](https://github.com/glorious-codes/glorious-triven#triven) to learn more.
+Refer to [Triven's Documentation](https://github.com/glorious-codes/glorious-triven#triven) to learn more.
 
 ## Contributing
 


### PR DESCRIPTION
This PR introduces the necessary change to improve "read more" links, adding to them a suffix containing the title of the respective blog post (only on screen readers).

In addition:
- Improves a11y for settings list, replacing "visibility hidden" and "display none" for other strategies.
- Fixes two typos on "introducing triven" demo post.